### PR TITLE
fix the flush-reloading

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ var streamer = function (configuration, callback) {
          self.Stream = spawn('ezstream', ['-c', 'ezstream-conf.xml']);
          self.Stream.on("exit", function () {
             console.log("[INFO] Ezstream is dead now.");
-            self.Stream.running = false;
+            self.running = false;
          });
          self.Stream.running = true;
       } catch (error) {


### PR DESCRIPTION
A little fix for enabling the `flushPlayList()` after adding a song

## Description
`index.js : line 60`
```DIFF
- self.Stream.running = true;
+ self.running = true;
```

I think it's just a writing mistake, but's it disable the "auto-reload" feature